### PR TITLE
Release MOBAdvertising 9.0.0

### DIFF
--- a/MOBAdvertising.podspec
+++ b/MOBAdvertising.podspec
@@ -1,15 +1,16 @@
 Pod::Spec.new do |s|
     s.name             = 'MOBAdvertising'
-    s.version          = '8.0.4'
-    s.summary          = 'A wrapper for GogleMobileAds that allows one to present banner ads that show with any application, including a tab bar application'
+    s.version          = '9.0.0'
+    s.summary          = 'Consent-gated adaptive Google Mobile Ads banners for UIKit applications'
     s.homepage         = 'https://github.com/Moballo-LLC/MOBAdvertising'
     s.license          = 'MIT'
     s.author           = { 'Jason Morcos - Moballo, LLC' => 'jason.morcos@moballo.com' }
     s.source           = { :git => 'https://github.com/Moballo-LLC/MOBAdvertising.git', :tag => s.version.to_s }
 
-    s.platforms = { :ios => "10.0" }
+    s.platforms = { :ios => "13.0" }
     s.swift_version = '5.0'
-    s.dependency 'Google-Mobile-Ads-SDK', '~> 9.14'
+    s.dependency 'Google-Mobile-Ads-SDK', '13.6.0'
+    s.dependency 'GoogleUserMessagingPlatform', '3.1.0'
 
     s.static_framework = true
 

--- a/README.md
+++ b/README.md
@@ -1,54 +1,68 @@
 # MOBAdvertising
-MOBAdvertising is an easy-to-use, drop-in wrapper for Google AdMob Banner Ads. Simply wrap your app in MOBAdvertising to display ads on the bottom in a jiffy.
-***
-## Import with CocoaPods
-```
-  use_frameworks!
-  pod 'MOBAdvertising'
-```
-***
-## Initialization and Setup
-### Info.plist
-- Define `GADApplicationIdentifier` to be your app's GAD Application Identifier
-- Add and customize the following keys:
-```
-<key>NSUserTrackingUsageDescription</key>
-<string>This app is expensive to develop and distribute. We rely on personalized advertising to gain sufficient revenue to continue development and support.</string>
-<key>SKAdNetworkItems</key>
-  <array>
-    <dict>
-      <key>SKAdNetworkIdentifier</key>
-      <string>cstr6suwn9.skadnetwork</string>
-    </dict>
-  </array> <key>NSAppTransportSecurity</key>
-<dict>
-    <key>NSAllowsArbitraryLoads</key>
-    <true/>
-    <key>NSAllowsArbitraryLoadsForMedia</key>
-    <true/>
-    <key>NSAllowsArbitraryLoadsInWebContent</key>
-    <true/>
-</dict>
-```
-### AppDelegate.swift
-#### At the top of the file
-```
-import MOBAdvertising
-var bannerViewControllered: MOBAdvertisingBanner!
-```
-#### Inside of "application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool"
-```
-bannerViewControllered = MOBAdvertisingBanner(view: (self.window?.rootViewController)!, AdUnitID: "YOUR ADMOB AD UNIT ID", ShouldShowAd: true, TestAdDevices: [String]?)
-self.window!.rootViewController = bannerViewControllered;
-self.window?.makeKeyAndVisible()
-```
-***
-## To Show/Hide Ads
-```
-bannerViewControllered.hideBannerView()
-or
-bannerViewControllered.showBannerView()
-```
-***
-Easy as pie! Enjoy!
 
+MOBAdvertising is a UIKit wrapper for consent-gated, anchored adaptive Google
+Mobile Ads banners. Version 9 requires iOS 13 or later and coordinates UMP,
+App Tracking Transparency, Mobile Ads startup, and banner loading in that order.
+
+## CocoaPods
+
+```ruby
+use_frameworks!
+pod 'MOBAdvertising', '9.0.0'
+```
+
+## Host configuration
+
+Add the app's production Google Mobile Ads application identifier to its
+`Info.plist`:
+
+```xml
+<key>GADApplicationIdentifier</key>
+<string>ca-app-pub-…~…</string>
+```
+
+If the app requests tracking authorization, add an accurate
+`NSUserTrackingUsageDescription`. Keep Google's current SKAdNetwork inventory
+in the host app when the app uses attribution. MOBAdvertising does not require
+arbitrary-load ATS exceptions; do not add them for the SDK.
+
+Publish the appropriate UMP consent and privacy-options messages in AdMob. The
+SDK cannot create that server-side configuration.
+
+## App setup
+
+```swift
+import MOBAdvertising
+
+private var bannerController: MOBAdvertisingBanner?
+
+func installBanner(around contentController: UIViewController) {
+    let controller = MOBAdvertisingBanner(
+        view: contentController,
+        AdUnitID: "YOUR PRODUCTION BANNER UNIT ID"
+    )
+    bannerController = controller
+    window?.rootViewController = controller
+    window?.makeKeyAndVisible()
+}
+```
+
+Debug and Simulator builds use Google's anchored-adaptive demo unit. A physical
+Release build uses the supplied production unit unless its launch environment
+contains `MOBALLO_USE_TEST_ADS=1`. Interact with a creative only after it is
+visibly labeled as a test ad.
+
+## Visibility and privacy options
+
+```swift
+bannerController?.hideBannerView()
+bannerController?.showBannerView()
+
+if bannerController?.shouldOfferPrivacyOptions == true {
+    bannerController?.presentPrivacyOptions(from: presentingViewController)
+}
+```
+
+Failed consent refreshes fail closed and retry while an active banner remains
+requested. Interrupted ATT prompts and transient banner failures use bounded
+retries; hiding the banner cancels pending per-banner retry work.

--- a/Tests/test_ad_policy.py
+++ b/Tests/test_ad_policy.py
@@ -37,6 +37,10 @@ assert '''if authorizationComplete {
         }''' in source
 assert 'sharedTrackingRetryAttempts < 3' in source
 assert 'UIApplication.didBecomeActiveNotification' in source
+assert 'presentSharedConsentFormWhenActive(from: presenter)' in source
+assert 'sharedConsentDidBecomeActiveObserver' in source
+assert 'guard UIApplication.shared.applicationState == .active else' in source
+assert 'stopObservingSharedConsentApplicationActivation()' in source
 assert 'bannerRetryAttempts < 5' in source
 assert 'scheduleBannerRetryIfNeeded()' in source
 assert 'guard self.shouldBeShown, self.isViewVisible' in source
@@ -51,6 +55,7 @@ assert '''public var shouldOfferPrivacyOptions: Bool {
         ConsentInformation.shared.privacyOptionsRequirementStatus == .required
     }''' in source
 assert 'bannerView.delegate = nil' in source
+assert 'bannerRetryAttempts = 0' in source
 assert 'bannerView = BannerView(adSize: AdSizeBanner)' in source
 assert source.count('guard bannerView === self.bannerView else { return }') == 2
 assert 'lastLaidOutAvailableWidth = availableWidth' in source

--- a/Tests/test_ad_policy.py
+++ b/Tests/test_ad_policy.py
@@ -36,6 +36,13 @@ assert 'scheduleBannerRetryIfNeeded()' in source
 assert 'guard self.shouldBeShown, self.isViewVisible' in source
 assert 'requestedBannerWidth = availableWidth' in source
 assert 'requestedWidthMatchesCurrentLayout' in source
+assert 'self.replaceBannerView()' in source
+assert 'bannerView.delegate = nil' in source
+assert 'bannerView = BannerView(adSize: AdSizeBanner)' in source
+assert source.count('guard bannerView === self.bannerView else { return }') == 2
+assert 'lastLaidOutAvailableWidth = availableWidth' in source
+assert 'availableWidthChanged' in source
+assert 'previousBounds?.width != view.bounds.width' not in source
 assert "Google-Mobile-Ads-SDK', '13.6.0'" in spec
 assert "GoogleUserMessagingPlatform', '3.1.0'" in spec
 assert 'ios => "13.0"' in spec

--- a/Tests/test_ad_policy.py
+++ b/Tests/test_ad_policy.py
@@ -36,7 +36,11 @@ assert 'scheduleBannerRetryIfNeeded()' in source
 assert 'guard self.shouldBeShown, self.isViewVisible' in source
 assert 'requestedBannerWidth = availableWidth' in source
 assert 'requestedWidthMatchesCurrentLayout' in source
-assert 'self.replaceBannerView()' in source
+assert 'replaceBannerView()' in source
+assert 'NotificationName.privacyChoicesDidChange' in source
+assert 'selector: #selector(privacyChoicesDidChange)' in source
+assert 'name: NotificationName.privacyChoicesDidChange' in source
+assert '@objc private func privacyChoicesDidChange()' in source
 assert 'bannerView.delegate = nil' in source
 assert 'bannerView = BannerView(adSize: AdSizeBanner)' in source
 assert source.count('guard bannerView === self.bannerView else { return }') == 2

--- a/Tests/test_ad_policy.py
+++ b/Tests/test_ad_policy.py
@@ -51,6 +51,13 @@ assert 'NotificationName.privacyChoicesDidChange' in source
 assert 'selector: #selector(privacyChoicesDidChange)' in source
 assert 'name: NotificationName.privacyChoicesDidChange' in source
 assert '@objc private func privacyChoicesDidChange()' in source
+assert '''if authorizationComplete {
+            loadBannerIfPossible()
+        } else {
+            authorizationRetryAttempts = 0
+            authorizationRetryScheduled = false
+            beginAuthorizationIfNeeded()
+        }''' in source
 assert '''public var shouldOfferPrivacyOptions: Bool {
         ConsentInformation.shared.privacyOptionsRequirementStatus == .required
     }''' in source

--- a/Tests/test_ad_policy.py
+++ b/Tests/test_ad_policy.py
@@ -29,6 +29,12 @@ assert 'Configured Moballo banner; demo=' in source
 assert 'Moballo banner loaded successfully' in source
 assert 'retryableFailure' in source
 assert 'authorizationRetryAttempts < 3' in source
+assert '''if authorizationComplete {
+            if !adLoaded || pendingAdLoad {
+                loadBannerIfPossible()
+            }
+            return
+        }''' in source
 assert 'sharedTrackingRetryAttempts < 3' in source
 assert 'UIApplication.didBecomeActiveNotification' in source
 assert 'bannerRetryAttempts < 5' in source

--- a/Tests/test_ad_policy.py
+++ b/Tests/test_ad_policy.py
@@ -5,6 +5,10 @@ root = Path(__file__).resolve().parents[1]
 source = (root / "_Project/Sources/MOBAdvertisingBanner.swift").read_text()
 spec = (root / "MOBAdvertising.podspec").read_text()
 readme = (root / "README.md").read_text()
+podfile = (root / "_Project/Podfile").read_text()
+lockfile = (root / "_Project/Podfile.lock").read_text()
+project = (root / "_Project/MOBAdvertising.xcodeproj/project.pbxproj").read_text()
+info_plist = (root / "_Project/Sources/Info.plist").read_text()
 
 required_in_order = [
     "requestConsentInfoUpdate",
@@ -30,9 +34,23 @@ assert 'UIApplication.didBecomeActiveNotification' in source
 assert 'bannerRetryAttempts < 5' in source
 assert 'scheduleBannerRetryIfNeeded()' in source
 assert 'guard self.shouldBeShown, self.isViewVisible' in source
+assert 'requestedBannerWidth = availableWidth' in source
+assert 'requestedWidthMatchesCurrentLayout' in source
 assert "Google-Mobile-Ads-SDK', '13.6.0'" in spec
 assert "GoogleUserMessagingPlatform', '3.1.0'" in spec
 assert 'ios => "13.0"' in spec
+assert "platform :ios, '13.0'" in podfile
+assert "pod 'Google-Mobile-Ads-SDK', '13.6.0'" in podfile
+assert "pod 'GoogleUserMessagingPlatform', '3.1.0'" in podfile
+assert 'Google-Mobile-Ads-SDK (13.6.0)' in lockfile
+assert 'GoogleUserMessagingPlatform (3.1.0)' in lockfile
+assert project.count('CURRENT_PROJECT_VERSION = 9000;') == 2
+assert project.count('MARKETING_VERSION = 9.0.0;') == 2
+assert 'IPHONEOS_DEPLOYMENT_TARGET = 10.0;' not in project
+assert 'FRAMEWORK_SEARCH_PATHS = "";' not in project
+assert 'HEADER_SEARCH_PATHS = "";' not in project
+assert 'OTHER_LDFLAGS = "";' not in project
+assert '<string>6.0</string>' in info_plist
 assert "pod 'MOBAdvertising', '9.0.0'" in readme
 assert 'MOBALLO_USE_TEST_ADS=1' in readme
 assert 'does not require\narbitrary-load ATS exceptions' in readme

--- a/Tests/test_ad_policy.py
+++ b/Tests/test_ad_policy.py
@@ -51,6 +51,15 @@ assert 'NotificationName.privacyChoicesDidChange' in source
 assert 'selector: #selector(privacyChoicesDidChange)' in source
 assert 'name: NotificationName.privacyChoicesDidChange' in source
 assert '@objc private func privacyChoicesDidChange()' in source
+assert 'selector: #selector(applicationDidBecomeActive)' in source
+assert '@objc private func applicationDidBecomeActive()' in source
+assert source.count('UIApplication.shared.applicationState == .active') >= 3
+assert '''if !adLoaded || pendingAdLoad {
+                loadBannerIfPossible()
+            }
+        } else {
+            beginAuthorizationIfNeeded()
+        }''' in source
 assert '''if authorizationComplete {
             loadBannerIfPossible()
         } else {

--- a/Tests/test_ad_policy.py
+++ b/Tests/test_ad_policy.py
@@ -41,6 +41,9 @@ assert 'NotificationName.privacyChoicesDidChange' in source
 assert 'selector: #selector(privacyChoicesDidChange)' in source
 assert 'name: NotificationName.privacyChoicesDidChange' in source
 assert '@objc private func privacyChoicesDidChange()' in source
+assert '''public var shouldOfferPrivacyOptions: Bool {
+        ConsentInformation.shared.privacyOptionsRequirementStatus == .required
+    }''' in source
 assert 'bannerView.delegate = nil' in source
 assert 'bannerView = BannerView(adSize: AdSizeBanner)' in source
 assert source.count('guard bannerView === self.bannerView else { return }') == 2

--- a/Tests/test_ad_policy.py
+++ b/Tests/test_ad_policy.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+source = (root / "_Project/Sources/MOBAdvertisingBanner.swift").read_text()
+spec = (root / "MOBAdvertising.podspec").read_text()
+readme = (root / "README.md").read_text()
+
+required_in_order = [
+    "requestConsentInfoUpdate",
+    "loadAndPresentIfRequired",
+    "requestTrackingAuthorization",
+    "MobileAds.shared.start",
+    "bannerView.load(request)",
+]
+positions = [source.index(item) for item in required_in_order]
+assert positions == sorted(positions), "Consent, ATT, SDK startup, and ad loading are out of order"
+assert 'ca-app-pub-3940256099942544/2435281174' in source
+assert '#elseif targetEnvironment(simulator)' in source
+assert 'bannerView.isAutoloadEnabled = false' in source
+assert 'ConsentInformation.shared.canRequestAds' in source
+assert 'allowed: false,\n                        retryableFailure: true' in source
+assert 'allowed: formError == nil && ConsentInformation.shared.canRequestAds' in source
+assert 'Configured Moballo banner; demo=' in source
+assert 'Moballo banner loaded successfully' in source
+assert 'retryableFailure' in source
+assert 'authorizationRetryAttempts < 3' in source
+assert 'sharedTrackingRetryAttempts < 3' in source
+assert 'UIApplication.didBecomeActiveNotification' in source
+assert 'bannerRetryAttempts < 5' in source
+assert 'scheduleBannerRetryIfNeeded()' in source
+assert 'guard self.shouldBeShown, self.isViewVisible' in source
+assert "Google-Mobile-Ads-SDK', '13.6.0'" in spec
+assert "GoogleUserMessagingPlatform', '3.1.0'" in spec
+assert 'ios => "13.0"' in spec
+assert "pod 'MOBAdvertising', '9.0.0'" in readme
+assert 'MOBALLO_USE_TEST_ADS=1' in readme
+assert 'does not require\narbitrary-load ATS exceptions' in readme
+print("MOBAdvertising consent and demo-routing policy passed")

--- a/_Project/MOBAdvertising.xcodeproj/project.pbxproj
+++ b/_Project/MOBAdvertising.xcodeproj/project.pbxproj
@@ -190,6 +190,7 @@
 				1EAFA0D41B6039D5001F3D84 /* Frameworks */,
 				1EAFA0D51B6039D5001F3D84 /* Headers */,
 				1EAFA0D61B6039D5001F3D84 /* Resources */,
+				AB60A91B7D6A025E3A0ADF84 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -246,6 +247,26 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		AB60A91B7D6A025E3A0ADF84 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-MOBAdvertising_iOS/Pods-MOBAdvertising_iOS-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Google-Mobile-Ads-SDK/GoogleMobileAdsResources.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/GoogleUserMessagingPlatform/UserMessagingPlatformResources.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleMobileAdsResources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UserMessagingPlatformResources.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MOBAdvertising_iOS/Pods-MOBAdvertising_iOS-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		FEA2B48207252D27CE8ADBC7 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -317,7 +338,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_BITCODE = YES;
+				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -341,7 +362,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CFLAGS = "-fembed-bitcode";
 				OTHER_LDFLAGS = "$(inherited)";
 				SDKROOT = iphoneos;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/Modules";
@@ -388,7 +408,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_BITCODE = YES;
+				ENABLE_BITCODE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -405,7 +425,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CFLAGS = "-fembed-bitcode";
 				OTHER_LDFLAGS = "$(inherited)";
 				SDKROOT = iphoneos;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/Modules";
@@ -427,26 +446,19 @@
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 7100;
+				CURRENT_PROJECT_VERSION = 9000;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_BITCODE = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = "";
+				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 7.1.0;
+				MARKETING_VERSION = 9.0.0;
 				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-fembed-bitcode",
-				);
-				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.moballo.MOBAdvertising;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -469,27 +481,20 @@
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 7100;
+				CURRENT_PROJECT_VERSION = 9000;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_BITCODE = YES;
+				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 7.1.0;
+				MARKETING_VERSION = 9.0.0;
 				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-fembed-bitcode",
-				);
-				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.moballo.MOBAdvertising;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/_Project/Podfile
+++ b/_Project/Podfile
@@ -1,36 +1,17 @@
 target 'MOBAdvertising_iOS' do
-  platform :ios, '10.0'
+  platform :ios, '13.0'
   use_frameworks!
-  pod 'Google-Mobile-Ads-SDK', '~> 9.14'
+  pod 'Google-Mobile-Ads-SDK', '13.6.0'
+  pod 'GoogleUserMessagingPlatform', '3.1.0'
 
 end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
-      config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'
-
-      # build active architecture only (Debug build all)
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
       config.build_settings['ONLY_ACTIVE_ARCH'] = 'NO'
       config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'YES'
-
-      config.build_settings['ENABLE_BITCODE'] = 'YES'
-
-      if config.name == 'Release' || config.name == 'Pro'
-          config.build_settings['BITCODE_GENERATION_MODE'] = 'bitcode'
-      else # Debug
-          config.build_settings['BITCODE_GENERATION_MODE'] = 'marker'
-      end
-
-      cflags = config.build_settings['OTHER_CFLAGS'] || ['$(inherited)']
-
-      if config.name == 'Release' || config.name == 'Pro'
-          cflags << '-fembed-bitcode'
-      else # Debug
-          cflags << '-fembed-bitcode-marker'
-      end
-
-      config.build_settings['OTHER_CFLAGS'] = cflags
     end
   end
 end

--- a/_Project/Podfile.lock
+++ b/_Project/Podfile.lock
@@ -1,72 +1,21 @@
 PODS:
-  - Google-Mobile-Ads-SDK (9.14.0):
-    - GoogleAppMeasurement (< 11.0, >= 7.0)
+  - Google-Mobile-Ads-SDK (13.6.0):
     - GoogleUserMessagingPlatform (>= 1.1)
-  - GoogleAppMeasurement (10.5.0):
-    - GoogleAppMeasurement/AdIdSupport (= 10.5.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
-    - GoogleUtilities/MethodSwizzler (~> 7.8)
-    - GoogleUtilities/Network (~> 7.8)
-    - "GoogleUtilities/NSData+zlib (~> 7.8)"
-    - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (10.5.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.5.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
-    - GoogleUtilities/MethodSwizzler (~> 7.8)
-    - GoogleUtilities/Network (~> 7.8)
-    - "GoogleUtilities/NSData+zlib (~> 7.8)"
-    - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (10.5.0):
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
-    - GoogleUtilities/MethodSwizzler (~> 7.8)
-    - GoogleUtilities/Network (~> 7.8)
-    - "GoogleUtilities/NSData+zlib (~> 7.8)"
-    - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleUserMessagingPlatform (2.0.1)
-  - GoogleUtilities/AppDelegateSwizzler (7.11.0):
-    - GoogleUtilities/Environment
-    - GoogleUtilities/Logger
-    - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.11.0):
-    - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.11.0):
-    - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.11.0):
-    - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.11.0):
-    - GoogleUtilities/Logger
-    - "GoogleUtilities/NSData+zlib"
-    - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.11.0)"
-  - GoogleUtilities/Reachability (7.11.0):
-    - GoogleUtilities/Logger
-  - nanopb (2.30909.0):
-    - nanopb/decode (= 2.30909.0)
-    - nanopb/encode (= 2.30909.0)
-  - nanopb/decode (2.30909.0)
-  - nanopb/encode (2.30909.0)
-  - PromisesObjC (2.2.0)
+  - GoogleUserMessagingPlatform (3.1.0)
 
 DEPENDENCIES:
-  - Google-Mobile-Ads-SDK (~> 9.14)
+  - Google-Mobile-Ads-SDK (= 13.6.0)
+  - GoogleUserMessagingPlatform (= 3.1.0)
 
 SPEC REPOS:
   trunk:
     - Google-Mobile-Ads-SDK
-    - GoogleAppMeasurement
     - GoogleUserMessagingPlatform
-    - GoogleUtilities
-    - nanopb
-    - PromisesObjC
 
 SPEC CHECKSUMS:
-  Google-Mobile-Ads-SDK: 4fe6304b771f8467d29978cb790ec1e56e646946
-  GoogleAppMeasurement: 40c70a7d89013f0eca72006c4b9732163ea4cdae
-  GoogleUserMessagingPlatform: 5f8b30daf181805317b6b985bb51c1ff3beca054
-  GoogleUtilities: c2bdc4cf2ce786c4d2e6b3bcfd599a25ca78f06f
-  nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
-  PromisesObjC: 09985d6d70fbe7878040aa746d78236e6946d2ef
+  Google-Mobile-Ads-SDK: 6e501ace4af8d63e967bd45497c8b2b05821163d
+  GoogleUserMessagingPlatform: befe603da6501006420c206222acd449bba45a9c
 
-PODFILE CHECKSUM: e424c0338f848e12d1539d8b20c250ffcd23ce3f
+PODFILE CHECKSUM: c884693109862b238be2a5ed3cab57201fa170ef
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.16.2

--- a/_Project/Sources/Info.plist
+++ b/_Project/Sources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
-	<string>8.0.4</string>
+	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>

--- a/_Project/Sources/MOBAdvertisingBanner.swift
+++ b/_Project/Sources/MOBAdvertisingBanner.swift
@@ -33,7 +33,8 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
     private static var sharedMobileAdsStartWaiters: [() -> Void] = []
 
     private let contentController: UIViewController
-    private let bannerView = BannerView(adSize: AdSizeBanner)
+    private var bannerView = BannerView(adSize: AdSizeBanner)
+    private let bannerAdUnitID: String
     private let backgroundView = UIView()
     private let borderView = UIView()
     private let testDevices: [String]
@@ -52,6 +53,7 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
     private var bannerRetryAttempts = 0
     private var bannerRetryWorkItem: DispatchWorkItem?
     private var lastLaidOutBounds: CGRect?
+    private var lastLaidOutAvailableWidth: CGFloat?
     private var isViewVisible = false
 
     public init(
@@ -65,13 +67,11 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
         shouldBeShown = shouldShowAd
         testDevices = testAdDevices ?? []
         shouldRequestTrackingAuthorization = shouldRequestTrackingIDFA
+        bannerAdUnitID = Self.runtimeBannerAdUnitID(productionAdUnitID)
 
         super.init(nibName: nil, bundle: nil)
 
-        bannerView.adUnitID = Self.runtimeBannerAdUnitID(productionAdUnitID)
-        bannerView.rootViewController = self
-        bannerView.delegate = self
-        bannerView.isAutoloadEnabled = false
+        configureBannerView()
         #if DEBUG
         NSLog("Configured Moballo banner; demo=\(bannerView.adUnitID == Self.googleDemoBannerAdUnitID)")
         #endif
@@ -148,12 +148,20 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
 
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        let previousBounds = lastLaidOutBounds
         lastLaidOutBounds = view.bounds
 
         let borderSize = CGFloat(1)
         let safeInsets = view.window?.safeAreaInsets ?? view.safeAreaInsets
         let availableWidth = max(0, view.bounds.width - safeInsets.left - safeInsets.right)
+        let previousAvailableWidth = lastLaidOutAvailableWidth
+        lastLaidOutAvailableWidth = availableWidth
+        let availableWidthChanged = previousAvailableWidth.map {
+            abs($0 - availableWidth) >= 0.5
+        } ?? false
+        if availableWidthChanged {
+            adLoaded = false
+            pendingAdLoad = shouldBeShown
+        }
         guard availableWidth > 0 else {
             contentController.view.frame = view.bounds
             setPresentingAd(false)
@@ -196,11 +204,7 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
         borderView.frame = borderFrame
         backgroundView.frame = backgroundFrame
 
-        if previousBounds?.width != view.bounds.width || pendingAdLoad {
-            if previousBounds?.width != view.bounds.width {
-                adLoaded = false
-                pendingAdLoad = shouldBeShown
-            }
+        if availableWidthChanged || pendingAdLoad {
             loadBannerIfPossible()
         }
     }
@@ -260,7 +264,7 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
                 }
                 #endif
                 guard let self else { return }
-                self.adLoaded = false
+                self.replaceBannerView()
                 self.pendingAdLoad = self.shouldBeShown
                 self.reloadLayout()
                 self.loadBannerIfPossible()
@@ -269,6 +273,7 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
     }
 
     public func bannerViewDidReceiveAd(_ bannerView: BannerView) {
+        guard bannerView === self.bannerView else { return }
         bannerRequestInFlight = false
         guard requestedWidthMatchesCurrentLayout else {
             requestedBannerWidth = nil
@@ -299,6 +304,7 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
     }
 
     public func bannerView(_ bannerView: BannerView, didFailToReceiveAdWithError error: Error) {
+        guard bannerView === self.bannerView else { return }
         bannerRequestInFlight = false
         if !requestedWidthMatchesCurrentLayout {
             requestedBannerWidth = nil
@@ -545,6 +551,29 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
             request.scene = view.window?.windowScene
         }
         bannerView.load(request)
+    }
+
+    private func configureBannerView() {
+        bannerView.adUnitID = bannerAdUnitID
+        bannerView.rootViewController = self
+        bannerView.delegate = self
+        bannerView.isAutoloadEnabled = false
+    }
+
+    private func replaceBannerView() {
+        bannerRetryWorkItem?.cancel()
+        bannerRetryWorkItem = nil
+        bannerRequestInFlight = false
+        requestedBannerWidth = nil
+        adLoaded = false
+
+        bannerView.delegate = nil
+        bannerView.removeFromSuperview()
+        bannerView = BannerView(adSize: AdSizeBanner)
+        configureBannerView()
+        if isViewLoaded {
+            view.insertSubview(bannerView, belowSubview: contentController.view)
+        }
     }
 
     private var requestedWidthMatchesCurrentLayout: Bool {

--- a/_Project/Sources/MOBAdvertisingBanner.swift
+++ b/_Project/Sources/MOBAdvertisingBanner.swift
@@ -1,292 +1,608 @@
 //
-//  AdBannerController.swift
+//  MOBAdvertisingBanner.swift
 //  MOBAdvertising
 //
-//  Created by Jason Morcos on 11/23/16.
-//  Copyright © 2016 CBTech. All rights reserved.
+//  Consent-gated adaptive banner presentation for Moballo UIKit apps.
 //
 
+import UIKit
+import GoogleMobileAds
+import UserMessagingPlatform
+#if canImport(AppTrackingTransparency)
+import AppTrackingTransparency
+#endif
 
-#if canImport(GoogleMobileAds)
-    import UIKit
-    import GoogleMobileAds
-    #if canImport(AppTrackingTransparency)
-    import AppTrackingTransparency
-    #endif
-    import AdSupport
+public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
+    private enum NotificationName {
+        static let didPresent = Notification.Name("com.moballo.advertising.adPresented")
+        static let didUnpresent = Notification.Name("com.moballo.advertising.adUnpresented")
+    }
 
-    public class MOBAdvertisingBanner: UIViewController, GADBannerViewDelegate {
-        @objc var adUnitID:String!
-        @objc var bannerView:GADBannerView!
-        @objc var borderView:UIView!
-        @objc var backgroundView:UIView!
-        @objc var adLoaded = false
-        @objc var shouldBeShown = false
-        @objc var presentingAd = false
-        @objc var contentController:UIViewController!
-        var frameSavedBannerView:CGRect!
-        var pendingFrameChange = false
-        @objc let DidPresentAd = "com.moballo.advertising.adPresented"
-        @objc let DidUnpresentAd = "com.moballo.advertising.adUnpresented"
-        @objc var testDevices:[String] = [String]()
-        @objc var simulatedDevices:[String] = [String]()
-        @objc var shouldRequestTrackingIDFA:Bool = false
+    private static let googleDemoBannerAdUnitID = "ca-app-pub-3940256099942544/2435281174"
+    private static var sharedConsentComplete = false
+    private static var sharedConsentInFlight = false
+    private static var sharedConsentWaiters: [(Bool, Bool) -> Void] = []
+    private static var sharedTrackingComplete = false
+    private static var sharedTrackingInFlight = false
+    private static var sharedTrackingWaiters: [() -> Void] = []
+    private static var sharedTrackingRetryAttempts = 0
+    private static var sharedTrackingRetryWorkItem: DispatchWorkItem?
+    private static var sharedDidBecomeActiveObserver: NSObjectProtocol?
+    private static var sharedMobileAdsStarted = false
+    private static var sharedMobileAdsStartInFlight = false
+    private static var sharedMobileAdsStartWaiters: [() -> Void] = []
 
-        override public func viewDidLoad() {
-            super.viewDidLoad()
+    private let contentController: UIViewController
+    private let bannerView = BannerView(adSize: AdSizeBanner)
+    private let backgroundView = UIView()
+    private let borderView = UIView()
+    private let testDevices: [String]
+    private let shouldRequestTrackingAuthorization: Bool
 
-            // Do any additional setup after loading the view.
+    private var adLoaded = false
+    private var shouldBeShown: Bool
+    private var presentingAd = false
+    private var authorizationStarted = false
+    private var authorizationComplete = false
+    private var authorizationRetryAttempts = 0
+    private var authorizationRetryScheduled = false
+    private var bannerRequestInFlight = false
+    private var pendingAdLoad = false
+    private var bannerRetryAttempts = 0
+    private var bannerRetryWorkItem: DispatchWorkItem?
+    private var lastLaidOutBounds: CGRect?
+    private var isViewVisible = false
+
+    public init(
+        view content: UIViewController,
+        AdUnitID productionAdUnitID: String,
+        ShouldShowAd shouldShowAd: Bool = true,
+        TestAdDevices testAdDevices: [String]? = nil,
+        shouldRequestTrackingIDFA: Bool = true
+    ) {
+        contentController = content
+        shouldBeShown = shouldShowAd
+        testDevices = testAdDevices ?? []
+        shouldRequestTrackingAuthorization = shouldRequestTrackingIDFA
+
+        super.init(nibName: nil, bundle: nil)
+
+        bannerView.adUnitID = Self.runtimeBannerAdUnitID(productionAdUnitID)
+        bannerView.rootViewController = self
+        bannerView.delegate = self
+        bannerView.isAutoloadEnabled = false
+        #if DEBUG
+        NSLog("Configured Moballo banner; demo=\(bannerView.adUnitID == Self.googleDemoBannerAdUnitID)")
+        #endif
+    }
+
+    // Source compatibility for apps that used MOBAdvertising 1.x. The Google
+    // app ID must now live in GADApplicationIdentifier in the host Info.plist.
+    public convenience init(
+        view content: UIViewController,
+        AdApplicationID _: String,
+        AdUnitID productionAdUnitID: String,
+        TestAds _: Bool? = false
+    ) {
+        self.init(view: content, AdUnitID: productionAdUnitID)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("MOBAdvertisingBanner must be initialized with a content controller.")
+    }
+
+    deinit {
+        bannerRetryWorkItem?.cancel()
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    public override func loadView() {
+        let rootView = UIView(frame: .zero)
+        rootView.addSubview(backgroundView)
+        rootView.addSubview(borderView)
+        rootView.addSubview(bannerView)
+
+        addChild(contentController)
+        rootView.addSubview(contentController.view)
+        contentController.didMove(toParent: self)
+        view = rootView
+    }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        applySystemColors()
+    }
+
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        isViewVisible = true
+        if lastLaidOutBounds != view.bounds {
+            reloadLayout()
         }
-        public init(view content: UIViewController, AdUnitID adUnitIDInit:String, ShouldShowAd showAdsIn: Bool = true, TestAdDevices testDevicesIn: [String]? = nil, shouldRequestTrackingIDFA: Bool = true) {
-            //Show test ads on these explicit devices
-            self.testDevices = testDevicesIn ?? [String]()
-            self.simulatedDevices = [String]()
-            if let simulatorStringed = GADSimulatorID as? String {
-                self.simulatedDevices.append(simulatorStringed)
-            }
-            //Request IDFA Access usually
-            self.shouldRequestTrackingIDFA = shouldRequestTrackingIDFA
-            //Show an ad as soon as available
-            self.shouldBeShown = showAdsIn
-            //Set that no ad loaded yet
-            self.adLoaded = false
-            //Get ad info from init
-            self.adUnitID = adUnitIDInit
-            //Init Super View Controller
-            super.init(nibName: nil, bundle: nil)
-            //Setup Main View
-            self.contentController = content
-            //Setup below ad Background View
-            self.backgroundView = UIView()
-            //Setup ad border View
-            self.borderView = UIView()
-            //Setup Ad Banner View
-            self.bannerView = GADBannerView(adSize: GADAdSizeBanner)
-            self.bannerView.adUnitID = self.adUnitID;
-            self.bannerView.rootViewController = self;
-            self.bannerView.delegate = self
-            //Set main view background color
-            if #available(iOS 13.0, *) {
-                self.setBackground(color: UIColor.systemBackground)
-                self.bannerView.backgroundColor = UIColor.systemGray6
-                self.borderView.backgroundColor = UIColor.systemGray6
-            } else {
-                self.setBackground(color: UIColor.white)
-                self.bannerView.backgroundColor = UIColor.lightGray
-                self.borderView.backgroundColor = UIColor.lightGray
-            }
-            //Init Google Ads framework
-            GADMobileAds.sharedInstance().start { (status) in
-                //Call Banner Load - ask for an ad
-                self.requestIDFA()
-            }
+        beginAuthorizationIfNeeded()
+    }
+
+    public override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        isViewVisible = false
+        bannerRetryWorkItem?.cancel()
+        bannerRetryWorkItem = nil
+    }
+
+    public override func viewWillTransition(
+        to size: CGSize,
+        with coordinator: UIViewControllerTransitionCoordinator
+    ) {
+        super.viewWillTransition(to: size, with: coordinator)
+        adLoaded = false
+        pendingAdLoad = shouldBeShown
+        coordinator.animate(alongsideTransition: { _ in
+            self.view.setNeedsLayout()
+            self.view.layoutIfNeeded()
+        }, completion: { _ in
+            self.loadBannerIfPossible()
+        })
+    }
+
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        let previousBounds = lastLaidOutBounds
+        lastLaidOutBounds = view.bounds
+
+        let borderSize = CGFloat(1)
+        let safeInsets = view.window?.safeAreaInsets ?? view.safeAreaInsets
+        let availableWidth = max(0, view.bounds.width - safeInsets.left - safeInsets.right)
+        guard availableWidth > 0 else {
+            contentController.view.frame = view.bounds
+            setPresentingAd(false)
+            pendingAdLoad = shouldBeShown
+            return
         }
-        public func getContentController() -> UIViewController {
-            return self.contentController
+
+        let adSize = largeAnchoredAdaptiveBanner(width: availableWidth)
+        bannerView.adSize = adSize
+        var contentFrame = view.bounds
+        var bannerFrame = CGRect(
+            x: safeInsets.left + max(0, (availableWidth - adSize.size.width) / 2),
+            y: view.bounds.maxY + borderSize,
+            width: adSize.size.width,
+            height: adSize.size.height
+        )
+        var borderFrame = CGRect(x: 0, y: view.bounds.maxY, width: view.bounds.width, height: borderSize)
+        var backgroundFrame = CGRect(
+            x: 0,
+            y: bannerFrame.minY,
+            width: view.bounds.width,
+            height: adSize.size.height + safeInsets.bottom
+        )
+
+        if adLoaded && shouldBeShown {
+            contentFrame.size.height = max(
+                0,
+                view.bounds.height - adSize.size.height - safeInsets.bottom - borderSize
+            )
+            borderFrame.origin.y = contentFrame.maxY
+            bannerFrame.origin.y = borderFrame.maxY
+            backgroundFrame.origin.y = bannerFrame.minY
+            setPresentingAd(true)
+        } else {
+            setPresentingAd(false)
         }
-        public func setBackground(color: UIColor) {
-            self.view.window?.backgroundColor = color
-            self.view.backgroundColor = color
+
+        contentController.view.frame = contentFrame
+        bannerView.frame = bannerFrame
+        borderView.frame = borderFrame
+        backgroundView.frame = backgroundFrame
+
+        if previousBounds?.width != view.bounds.width || pendingAdLoad {
+            if previousBounds?.width != view.bounds.width {
+                adLoaded = false
+                pendingAdLoad = shouldBeShown
+            }
+            loadBannerIfPossible()
+        }
+    }
+
+    public override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        contentController.supportedInterfaceOrientations
+    }
+
+    public override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+        contentController.preferredInterfaceOrientationForPresentation
+    }
+
+    public override var childForStatusBarStyle: UIViewController? { contentController }
+    public override var childForStatusBarHidden: UIViewController? { contentController }
+
+    public func getContentController() -> UIViewController { contentController }
+
+    public func setBackground(color: UIColor) {
+        view.backgroundColor = color
+        view.window?.backgroundColor = color
+        backgroundView.backgroundColor = color
+    }
+
+    @objc public func hideBannerView() {
+        shouldBeShown = false
+        pendingAdLoad = false
+        adLoaded = false
+        bannerRetryAttempts = 0
+        bannerRetryWorkItem?.cancel()
+        bannerRetryWorkItem = nil
+        bannerView.isAutoloadEnabled = false
+        reloadLayout()
+    }
+
+    @objc public func showBannerView() {
+        guard !shouldBeShown else { return }
+        shouldBeShown = true
+        pendingAdLoad = true
+        beginAuthorizationIfNeeded()
+        reloadLayout()
+    }
+
+    @objc public func isPresentingAd() -> Bool { presentingAd }
+
+    public var shouldOfferPrivacyOptions: Bool {
+        authorizationComplete
+            && ConsentInformation.shared.privacyOptionsRequirementStatus == .required
+    }
+
+    public func presentPrivacyOptions(from presenter: UIViewController) {
+        guard shouldOfferPrivacyOptions else { return }
+        ConsentForm.presentPrivacyOptionsForm(from: presenter) { [weak self] error in
             DispatchQueue.main.async {
-                self.backgroundView?.backgroundColor = color
-                self.view.window?.backgroundColor = color
-                self.view.backgroundColor = color
-            }
-        }
-        private func requestIDFA() {
-            if(!shouldRequestTrackingIDFA) {
-                self.bannerLoad()
-                NSLog("adView:ASIdentifierManager NOT REQUESTING IDFA ACCESS")
-                return
-            }
-
-            NSLog("adView:ASIdentifierManager Tracking UUID: " + ASIdentifierManager.shared().advertisingIdentifier.uuidString)
-            #if canImport(AppTrackingTransparency)
-                if #available(iOS 14, *) {
-                    //Guard for application not yet being active
-                    if(UIApplication.shared.applicationState != .active) {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
-                            self.requestIDFA()
-                        })
-                        return;
-                    }
-
-                    //Request authorization
-                    if(ATTrackingManager.trackingAuthorizationStatus == .notDetermined) {
-                        ATTrackingManager.requestTrackingAuthorization(completionHandler: { status in
-                            // Tracking authorization completed. Start loading ads here.
-                            if status == ATTrackingManager.AuthorizationStatus.authorized {
-                                NSLog("adView:ASIdentifierManager ATTrackingManager=authorized")
-                            } else if status == ATTrackingManager.AuthorizationStatus.denied {
-                                NSLog("adView:ASIdentifierManager ATTrackingManager=denied")
-                            } else if status == ATTrackingManager.AuthorizationStatus.restricted {
-                                NSLog("adView:ASIdentifierManager ATTrackingManager=restricted")
-                            } else if status == ATTrackingManager.AuthorizationStatus.notDetermined {
-                                NSLog("adView:ASIdentifierManager ATTrackingManager=notDetermined")
-                            } else {
-                                NSLog("adView:ASIdentifierManager ATTrackingManager=UNKNOWN STATE OCCURED")
-                            }
-
-                            //Check for failed check for tracking advertising
-                            if(status == .notDetermined) {
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
-                                    self.requestIDFA()
-                                })
-                                return;
-                            }
-
-                            self.bannerLoad()
-                        })
-                        return;
-                    }
-                    
+                #if DEBUG
+                if let error {
+                    NSLog("Unable to present advertising privacy options: \(error.localizedDescription)")
                 }
-            #endif
-            NSLog("adView:ASIdentifierManager skipping requesting tracking permission. ASIdentifierManager.isAdvertisingTrackingEnabled=" + (ASIdentifierManager.shared().isAdvertisingTrackingEnabled ? "Yes" : "No"));
-            
-
-            self.bannerLoad()
-        }
-        private func bannerLoad() {
-            DispatchQueue.main.async {
-                self.bannerView.adSize = GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth(self.bannerView.frame.size.width);
-                NSLog("adView:requesting ad with width=" + String(Int(self.bannerView.adSize.size.width)))
-                let request = GADRequest()
-                if #available(iOS 13.0, *) {
-                    request.scene = self.view.window?.windowScene
-                }
-                GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = self.testDevices + self.simulatedDevices
-                self.bannerView.load(request)
-                self.bannerView.isAutoloadEnabled = true
-            }
-        }
-        required public init?(coder aDecoder: NSCoder) {
-            super.init(coder: aDecoder)
-        }
-
-        override public func didReceiveMemoryWarning() {
-            super.didReceiveMemoryWarning()
-            // Dispose of any resources that can be recreated.
-        }
-
-
-        override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-            UIView.animate(withDuration: 0.25, animations: ({
-                self.view.setNeedsLayout()
-                self.view.layoutIfNeeded()
-            }))
-
-            if (self.bannerView != nil) {
+                #endif
+                guard let self else { return }
                 self.adLoaded = false
-                self.pendingFrameChange = true
-            }
-            super.viewWillTransition(to: size, with: coordinator)
-        }
-
-        override public func loadView() {
-            let content = UIView(frame: UIScreen.main.bounds)
-            content.addSubview(self.backgroundView)
-            content.addSubview(self.borderView)
-            content.addSubview(self.bannerView)
-            self.addChild(self.contentController)
-            content.addSubview(self.contentController.view)
-            self.contentController.didMove(toParent: self)
-            content.backgroundColor = UIColor.black
-            self.view = content
-        }
-        override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-            return self.contentController.supportedInterfaceOrientations
-        }
-
-        override public var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
-            return self.contentController.preferredInterfaceOrientationForPresentation
-        }
-
-        override public func viewDidAppear(_ animated: Bool) {
-            super.viewDidAppear(animated)
-            if (!self.view.bounds.equalTo(self.frameSavedBannerView)) {
-                self.reloadStuff()
-            }
-        }
-        private func reloadStuff() {
-            DispatchQueue.main.async {
-                UIView.animate(withDuration: 0.25, animations: ({
-                    self.view.setNeedsLayout()
-                    if self.view.window != nil {
-                        self.view.layoutIfNeeded()
-                    }
-                }))
-            }
-        }
-        @objc public func hideBannerView() {
-            self.shouldBeShown = false;
-            self.reloadStuff()
-        }
-        @objc public func showBannerView() {
-            self.shouldBeShown = true;
-            self.reloadStuff()
-        }
-        public func bannerViewDidReceiveAd(_ bannerView: GADBannerView) {
-            if(self.pendingFrameChange) {
-                return
-            }
-            self.adLoaded = true
-            self.frameSavedBannerView = CGRect.zero
-            NSLog("bannerViewDidReceiveAd")
-            self.reloadStuff()
-        }
-        public func bannerView(_ bannerView: GADBannerView, didFailToReceiveAdWithError error: Error) {
-            NSLog("bannerView:didFailToReceiveAdWithError: "+error.localizedDescription)
-            self.reloadStuff()
-        }
-        @objc public func isPresentingAd() -> Bool {
-            return presentingAd
-        }
-        override public func viewDidLayoutSubviews() {
-            var contentFrame = self.view.bounds
-            var bannerFrame = CGRect.zero
-            self.frameSavedBannerView = self.view.bounds
-            bannerFrame.size = self.bannerView.sizeThatFits(contentFrame.size)
-            bannerFrame.size.width = self.view.bounds.size.width
-            var backgroundViewFrame = bannerFrame
-            var borderViewFrame = bannerFrame
-            let borderSize = CGFloat(1.0)
-            borderViewFrame.size.height = borderSize
-            var displayShift = bannerFrame.size.height
-            if #available(iOS 11.0, *) {
-                let insets = self.view.window?.safeAreaInsets ?? self.view.safeAreaInsets
-                bannerFrame.origin.x = insets.left
-                bannerFrame.size.width -= insets.left
-                bannerFrame.size.width -= insets.right
-                displayShift += insets.bottom
-            }
-
-            // Check if the banner has an ad loaded and ready for display.  Move the banner off
-            // screen if it does not have an ad.
-            if (self.adLoaded && self.shouldBeShown) {
-                contentFrame.size.height -= displayShift - borderSize
-                bannerFrame.origin.y = contentFrame.size.height + borderSize;
-                borderViewFrame.origin.y = contentFrame.size.height;
-                backgroundViewFrame.origin.y = bannerFrame.origin.y
-                backgroundViewFrame.size.height += displayShift
-                NotificationCenter.default.post(name: Notification.Name(rawValue: self.DidPresentAd), object: nil)
-                self.presentingAd = true
-            } else {
-                bannerFrame.origin.y = contentFrame.size.height + borderSize
-                borderViewFrame.origin.y = contentFrame.size.height
-                NotificationCenter.default.post(name: Notification.Name(rawValue: self.DidUnpresentAd), object: nil)
-                self.presentingAd = false
-            }
-            self.contentController.view.frame = contentFrame
-            self.bannerView.frame = bannerFrame
-            self.borderView.frame = borderViewFrame
-            self.backgroundView.frame = backgroundViewFrame
-            self.bannerView.adSize = GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth(self.bannerView.frame.size.width)
-            bannerFrame.origin.x = (contentFrame.size.width - self.bannerView.adSize.size.width) / 2.0
-            if(self.pendingFrameChange) {
-                self.pendingFrameChange = false
-                self.bannerLoad()
+                self.pendingAdLoad = self.shouldBeShown
+                self.reloadLayout()
+                self.loadBannerIfPossible()
             }
         }
     }
-#endif
+
+    public func bannerViewDidReceiveAd(_ bannerView: BannerView) {
+        bannerRequestInFlight = false
+        guard shouldBeShown,
+              authorizationComplete,
+              ConsentInformation.shared.canRequestAds else {
+            adLoaded = false
+            reloadLayout()
+            return
+        }
+        pendingAdLoad = false
+        adLoaded = true
+        bannerRetryAttempts = 0
+        bannerRetryWorkItem?.cancel()
+        bannerRetryWorkItem = nil
+        bannerView.isAutoloadEnabled = false
+        #if DEBUG
+        NSLog("Moballo banner loaded successfully")
+        #endif
+        reloadLayout()
+    }
+
+    public func bannerView(_ bannerView: BannerView, didFailToReceiveAdWithError error: Error) {
+        bannerRequestInFlight = false
+        pendingAdLoad = false
+        adLoaded = false
+        bannerView.isAutoloadEnabled = false
+        #if DEBUG
+        NSLog("Unable to load Moballo banner ad: \(error.localizedDescription)")
+        #endif
+        reloadLayout()
+        scheduleBannerRetryIfNeeded()
+    }
+
+    private static func runtimeBannerAdUnitID(_ productionAdUnitID: String) -> String {
+        #if DEBUG
+        return googleDemoBannerAdUnitID
+        #elseif targetEnvironment(simulator)
+        return googleDemoBannerAdUnitID
+        #else
+        return ProcessInfo.processInfo.environment["MOBALLO_USE_TEST_ADS"] == "1"
+            ? googleDemoBannerAdUnitID
+            : productionAdUnitID
+        #endif
+    }
+
+    private func beginAuthorizationIfNeeded() {
+        guard shouldBeShown, isViewVisible else { return }
+        if authorizationComplete {
+            loadBannerIfPossible()
+            return
+        }
+        guard !authorizationStarted else { return }
+        authorizationStarted = true
+
+        Self.requestSharedConsent(from: self) { [weak self] consentAllowsAds, retryableFailure in
+            guard let self else { return }
+            guard consentAllowsAds else {
+                self.authorizationStarted = false
+                self.authorizationComplete = false
+                self.pendingAdLoad = false
+                self.adLoaded = false
+                self.reloadLayout()
+                if retryableFailure {
+                    self.scheduleAuthorizationRetry()
+                }
+                return
+            }
+            guard self.shouldBeShown, self.isViewVisible else {
+                self.authorizationStarted = false
+                return
+            }
+            self.authorizationRetryAttempts = 0
+            self.requestTrackingIfNeeded()
+        }
+    }
+
+    private static func requestSharedConsent(
+        from presenter: UIViewController,
+        completion: @escaping (Bool, Bool) -> Void
+    ) {
+        if sharedConsentComplete {
+            completion(ConsentInformation.shared.canRequestAds, false)
+            return
+        }
+        sharedConsentWaiters.append(completion)
+        guard !sharedConsentInFlight else { return }
+        sharedConsentInFlight = true
+
+        ConsentInformation.shared.requestConsentInfoUpdate(with: RequestParameters()) { error in
+            DispatchQueue.main.async {
+                guard error == nil else {
+                    #if DEBUG
+                    NSLog("Unable to update advertising consent: \(error!.localizedDescription)")
+                    #endif
+                    finishSharedConsent(
+                        allowed: false,
+                        retryableFailure: true
+                    )
+                    return
+                }
+                ConsentForm.loadAndPresentIfRequired(from: presenter) { formError in
+                    DispatchQueue.main.async {
+                        #if DEBUG
+                        if let formError {
+                            NSLog("Unable to present advertising consent: \(formError.localizedDescription)")
+                        }
+                        #endif
+                        finishSharedConsent(
+                            allowed: formError == nil && ConsentInformation.shared.canRequestAds,
+                            retryableFailure: formError != nil
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private static func finishSharedConsent(allowed: Bool, retryableFailure: Bool) {
+        sharedConsentInFlight = false
+        sharedConsentComplete = !retryableFailure
+        let waiters = sharedConsentWaiters
+        sharedConsentWaiters.removeAll()
+        waiters.forEach { $0(allowed, retryableFailure) }
+    }
+
+    private func scheduleAuthorizationRetry() {
+        guard authorizationRetryAttempts < 3,
+              !authorizationRetryScheduled,
+              shouldBeShown,
+              isViewVisible else { return }
+        authorizationRetryAttempts += 1
+        authorizationRetryScheduled = true
+        let delay = TimeInterval(5 * authorizationRetryAttempts)
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self else { return }
+            self.authorizationRetryScheduled = false
+            self.beginAuthorizationIfNeeded()
+        }
+    }
+
+    private func requestTrackingIfNeeded() {
+        guard shouldRequestTrackingAuthorization else {
+            startMobileAds()
+            return
+        }
+        Self.requestSharedTrackingAuthorization { [weak self] in
+            self?.startMobileAds()
+        }
+    }
+
+    private static func requestSharedTrackingAuthorization(completion: @escaping () -> Void) {
+        if sharedTrackingComplete {
+            completion()
+            return
+        }
+        sharedTrackingWaiters.append(completion)
+        guard !sharedTrackingInFlight else { return }
+        sharedTrackingInFlight = true
+
+        performSharedTrackingAuthorizationRequest()
+    }
+
+    private static func performSharedTrackingAuthorizationRequest() {
+        #if canImport(AppTrackingTransparency)
+        if #available(iOS 14, *), ATTrackingManager.trackingAuthorizationStatus == .notDetermined {
+            guard UIApplication.shared.applicationState == .active else {
+                observeNextSharedApplicationActivation()
+                return
+            }
+            ATTrackingManager.requestTrackingAuthorization { _ in
+                DispatchQueue.main.async {
+                    if ATTrackingManager.trackingAuthorizationStatus == .notDetermined,
+                       sharedTrackingRetryAttempts < 3 {
+                        scheduleSharedTrackingAuthorizationRetry()
+                    } else {
+                        finishSharedTrackingAuthorization()
+                    }
+                }
+            }
+            return
+        }
+        #endif
+        finishSharedTrackingAuthorization()
+    }
+
+    private static func finishSharedTrackingAuthorization() {
+        sharedTrackingRetryWorkItem?.cancel()
+        sharedTrackingRetryWorkItem = nil
+        sharedTrackingRetryAttempts = 0
+        stopObservingSharedApplicationActivation()
+        sharedTrackingInFlight = false
+        sharedTrackingComplete = true
+        let waiters = sharedTrackingWaiters
+        sharedTrackingWaiters.removeAll()
+        waiters.forEach { $0() }
+    }
+
+    private func startMobileAds() {
+        Self.startSharedMobileAds { [weak self] in
+            guard let self else { return }
+            guard self.shouldBeShown, self.isViewVisible else {
+                self.authorizationStarted = false
+                return
+            }
+            self.authorizationComplete = true
+            self.pendingAdLoad = self.shouldBeShown
+            self.loadBannerIfPossible()
+        }
+    }
+
+    private static func startSharedMobileAds(completion: @escaping () -> Void) {
+        if sharedMobileAdsStarted {
+            completion()
+            return
+        }
+        sharedMobileAdsStartWaiters.append(completion)
+        guard !sharedMobileAdsStartInFlight else { return }
+        sharedMobileAdsStartInFlight = true
+        #if DEBUG
+        NSLog("Initializing Mobile Ads after UMP and ATT")
+        #endif
+        MobileAds.shared.start { _ in
+            DispatchQueue.main.async {
+                sharedMobileAdsStartInFlight = false
+                sharedMobileAdsStarted = true
+                let waiters = sharedMobileAdsStartWaiters
+                sharedMobileAdsStartWaiters.removeAll()
+                waiters.forEach { $0() }
+            }
+        }
+    }
+
+    private func loadBannerIfPossible() {
+        guard shouldBeShown,
+              isViewVisible,
+              authorizationComplete,
+              ConsentInformation.shared.canRequestAds,
+              !bannerRequestInFlight,
+              bannerRetryWorkItem == nil else {
+            return
+        }
+        let safeInsets = view.window?.safeAreaInsets ?? view.safeAreaInsets
+        let availableWidth = max(0, view.bounds.width - safeInsets.left - safeInsets.right)
+        guard availableWidth > 0 else {
+            pendingAdLoad = true
+            return
+        }
+
+        pendingAdLoad = false
+        bannerRequestInFlight = true
+        bannerView.adSize = largeAnchoredAdaptiveBanner(width: availableWidth)
+        bannerView.isAutoloadEnabled = false
+        MobileAds.shared.requestConfiguration.testDeviceIdentifiers = testDevices
+        let request = Request()
+        if #available(iOS 13.0, *) {
+            request.scene = view.window?.windowScene
+        }
+        bannerView.load(request)
+    }
+
+    private static func observeNextSharedApplicationActivation() {
+        guard sharedDidBecomeActiveObserver == nil else { return }
+        sharedDidBecomeActiveObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            stopObservingSharedApplicationActivation()
+            performSharedTrackingAuthorizationRequest()
+        }
+    }
+
+    private static func stopObservingSharedApplicationActivation() {
+        guard let observer = sharedDidBecomeActiveObserver else { return }
+        NotificationCenter.default.removeObserver(observer)
+        sharedDidBecomeActiveObserver = nil
+    }
+
+    private static func scheduleSharedTrackingAuthorizationRetry() {
+        sharedTrackingRetryAttempts += 1
+        sharedTrackingRetryWorkItem?.cancel()
+        let delay = min(pow(2, Double(sharedTrackingRetryAttempts - 1)), 4)
+        let workItem = DispatchWorkItem {
+            sharedTrackingRetryWorkItem = nil
+            performSharedTrackingAuthorizationRequest()
+        }
+        sharedTrackingRetryWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    private func scheduleBannerRetryIfNeeded() {
+        guard bannerRetryAttempts < 5,
+              bannerRetryWorkItem == nil,
+              shouldBeShown,
+              isViewVisible,
+              authorizationComplete,
+              ConsentInformation.shared.canRequestAds else {
+            return
+        }
+
+        bannerRetryAttempts += 1
+        let delay = min(pow(2, Double(bannerRetryAttempts)), 32)
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.bannerRetryWorkItem = nil
+            self.pendingAdLoad = true
+            self.loadBannerIfPossible()
+        }
+        bannerRetryWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    private func applySystemColors() {
+        let backgroundColor = UIColor.systemBackground
+        let separatorColor = UIColor.systemGray6
+        view.backgroundColor = backgroundColor
+        backgroundView.backgroundColor = backgroundColor
+        borderView.backgroundColor = separatorColor
+        bannerView.backgroundColor = separatorColor
+    }
+
+    private func reloadLayout() {
+        DispatchQueue.main.async {
+            self.view.setNeedsLayout()
+            if self.view.window != nil {
+                self.view.layoutIfNeeded()
+            }
+        }
+    }
+
+    private func setPresentingAd(_ presenting: Bool) {
+        guard presentingAd != presenting else { return }
+        presentingAd = presenting
+        NotificationCenter.default.post(
+            name: presenting ? NotificationName.didPresent : NotificationName.didUnpresent,
+            object: nil
+        )
+    }
+}

--- a/_Project/Sources/MOBAdvertisingBanner.swift
+++ b/_Project/Sources/MOBAdvertisingBanner.swift
@@ -16,6 +16,9 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
     private enum NotificationName {
         static let didPresent = Notification.Name("com.moballo.advertising.adPresented")
         static let didUnpresent = Notification.Name("com.moballo.advertising.adUnpresented")
+        static let privacyChoicesDidChange = Notification.Name(
+            "com.moballo.advertising.privacyChoicesDidChange"
+        )
     }
 
     private static let googleDemoBannerAdUnitID = "ca-app-pub-3940256099942544/2435281174"
@@ -72,6 +75,12 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
         super.init(nibName: nil, bundle: nil)
 
         configureBannerView()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(privacyChoicesDidChange),
+            name: NotificationName.privacyChoicesDidChange,
+            object: nil
+        )
         #if DEBUG
         NSLog("Configured Moballo banner; demo=\(bannerView.adUnitID == Self.googleDemoBannerAdUnitID)")
         #endif
@@ -256,20 +265,27 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
 
     public func presentPrivacyOptions(from presenter: UIViewController) {
         guard shouldOfferPrivacyOptions else { return }
-        ConsentForm.presentPrivacyOptionsForm(from: presenter) { [weak self] error in
+        ConsentForm.presentPrivacyOptionsForm(from: presenter) { error in
             DispatchQueue.main.async {
                 #if DEBUG
                 if let error {
                     NSLog("Unable to present advertising privacy options: \(error.localizedDescription)")
                 }
                 #endif
-                guard let self else { return }
-                self.replaceBannerView()
-                self.pendingAdLoad = self.shouldBeShown
-                self.reloadLayout()
-                self.loadBannerIfPossible()
+                guard error == nil else { return }
+                NotificationCenter.default.post(
+                    name: NotificationName.privacyChoicesDidChange,
+                    object: nil
+                )
             }
         }
+    }
+
+    @objc private func privacyChoicesDidChange() {
+        replaceBannerView()
+        pendingAdLoad = shouldBeShown
+        reloadLayout()
+        loadBannerIfPossible()
     }
 
     public func bannerViewDidReceiveAd(_ bannerView: BannerView) {

--- a/_Project/Sources/MOBAdvertisingBanner.swift
+++ b/_Project/Sources/MOBAdvertisingBanner.swift
@@ -259,8 +259,7 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
     @objc public func isPresentingAd() -> Bool { presentingAd }
 
     public var shouldOfferPrivacyOptions: Bool {
-        authorizationComplete
-            && ConsentInformation.shared.privacyOptionsRequirementStatus == .required
+        ConsentInformation.shared.privacyOptionsRequirementStatus == .required
     }
 
     public func presentPrivacyOptions(from presenter: UIViewController) {

--- a/_Project/Sources/MOBAdvertisingBanner.swift
+++ b/_Project/Sources/MOBAdvertisingBanner.swift
@@ -83,6 +83,12 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
             name: NotificationName.privacyChoicesDidChange,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
         #if DEBUG
         NSLog("Configured Moballo banner; demo=\(bannerView.adUnitID == Self.googleDemoBannerAdUnitID)")
         #endif
@@ -291,6 +297,17 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
         } else {
             authorizationRetryAttempts = 0
             authorizationRetryScheduled = false
+            beginAuthorizationIfNeeded()
+        }
+    }
+
+    @objc private func applicationDidBecomeActive() {
+        guard shouldBeShown, isViewVisible else { return }
+        if authorizationComplete {
+            if !adLoaded || pendingAdLoad {
+                loadBannerIfPossible()
+            }
+        } else {
             beginAuthorizationIfNeeded()
         }
     }
@@ -587,6 +604,7 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
     private func loadBannerIfPossible() {
         guard shouldBeShown,
               isViewVisible,
+              UIApplication.shared.applicationState == .active,
               authorizationComplete,
               ConsentInformation.shared.canRequestAds,
               !bannerRequestInFlight,
@@ -679,6 +697,7 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
               bannerRetryWorkItem == nil,
               shouldBeShown,
               isViewVisible,
+              UIApplication.shared.applicationState == .active,
               authorizationComplete,
               ConsentInformation.shared.canRequestAds else {
             return

--- a/_Project/Sources/MOBAdvertisingBanner.swift
+++ b/_Project/Sources/MOBAdvertisingBanner.swift
@@ -286,7 +286,13 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
         replaceBannerView()
         pendingAdLoad = shouldBeShown
         reloadLayout()
-        loadBannerIfPossible()
+        if authorizationComplete {
+            loadBannerIfPossible()
+        } else {
+            authorizationRetryAttempts = 0
+            authorizationRetryScheduled = false
+            beginAuthorizationIfNeeded()
+        }
     }
 
     public func bannerViewDidReceiveAd(_ bannerView: BannerView) {

--- a/_Project/Sources/MOBAdvertisingBanner.swift
+++ b/_Project/Sources/MOBAdvertisingBanner.swift
@@ -47,6 +47,7 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
     private var authorizationRetryAttempts = 0
     private var authorizationRetryScheduled = false
     private var bannerRequestInFlight = false
+    private var requestedBannerWidth: CGFloat?
     private var pendingAdLoad = false
     private var bannerRetryAttempts = 0
     private var bannerRetryWorkItem: DispatchWorkItem?
@@ -269,6 +270,15 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
 
     public func bannerViewDidReceiveAd(_ bannerView: BannerView) {
         bannerRequestInFlight = false
+        guard requestedWidthMatchesCurrentLayout else {
+            requestedBannerWidth = nil
+            adLoaded = false
+            pendingAdLoad = shouldBeShown
+            reloadLayout()
+            loadBannerIfPossible()
+            return
+        }
+        requestedBannerWidth = nil
         guard shouldBeShown,
               authorizationComplete,
               ConsentInformation.shared.canRequestAds else {
@@ -290,6 +300,15 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
 
     public func bannerView(_ bannerView: BannerView, didFailToReceiveAdWithError error: Error) {
         bannerRequestInFlight = false
+        if !requestedWidthMatchesCurrentLayout {
+            requestedBannerWidth = nil
+            adLoaded = false
+            pendingAdLoad = shouldBeShown
+            reloadLayout()
+            loadBannerIfPossible()
+            return
+        }
+        requestedBannerWidth = nil
         pendingAdLoad = false
         adLoaded = false
         bannerView.isAutoloadEnabled = false
@@ -517,6 +536,7 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
 
         pendingAdLoad = false
         bannerRequestInFlight = true
+        requestedBannerWidth = availableWidth
         bannerView.adSize = largeAnchoredAdaptiveBanner(width: availableWidth)
         bannerView.isAutoloadEnabled = false
         MobileAds.shared.requestConfiguration.testDeviceIdentifiers = testDevices
@@ -525,6 +545,13 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
             request.scene = view.window?.windowScene
         }
         bannerView.load(request)
+    }
+
+    private var requestedWidthMatchesCurrentLayout: Bool {
+        guard let requestedBannerWidth else { return false }
+        let safeInsets = view.window?.safeAreaInsets ?? view.safeAreaInsets
+        let currentWidth = max(0, view.bounds.width - safeInsets.left - safeInsets.right)
+        return abs(requestedBannerWidth - currentWidth) < 0.5
     }
 
     private static func observeNextSharedApplicationActivation() {

--- a/_Project/Sources/MOBAdvertisingBanner.swift
+++ b/_Project/Sources/MOBAdvertisingBanner.swift
@@ -355,7 +355,9 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
     private func beginAuthorizationIfNeeded() {
         guard shouldBeShown, isViewVisible else { return }
         if authorizationComplete {
-            loadBannerIfPossible()
+            if !adLoaded || pendingAdLoad {
+                loadBannerIfPossible()
+            }
             return
         }
         guard !authorizationStarted else { return }

--- a/_Project/Sources/MOBAdvertisingBanner.swift
+++ b/_Project/Sources/MOBAdvertisingBanner.swift
@@ -25,6 +25,8 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
     private static var sharedConsentComplete = false
     private static var sharedConsentInFlight = false
     private static var sharedConsentWaiters: [(Bool, Bool) -> Void] = []
+    private static weak var sharedConsentPresenter: UIViewController?
+    private static var sharedConsentDidBecomeActiveObserver: NSObjectProtocol?
     private static var sharedTrackingComplete = false
     private static var sharedTrackingInFlight = false
     private static var sharedTrackingWaiters: [() -> Void] = []
@@ -409,24 +411,59 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
                     )
                     return
                 }
-                ConsentForm.loadAndPresentIfRequired(from: presenter) { formError in
-                    DispatchQueue.main.async {
-                        #if DEBUG
-                        if let formError {
-                            NSLog("Unable to present advertising consent: \(formError.localizedDescription)")
-                        }
-                        #endif
-                        finishSharedConsent(
-                            allowed: formError == nil && ConsentInformation.shared.canRequestAds,
-                            retryableFailure: formError != nil
-                        )
-                    }
-                }
+                presentSharedConsentFormWhenActive(from: presenter)
             }
         }
     }
 
+    private static func presentSharedConsentFormWhenActive(from presenter: UIViewController) {
+        guard UIApplication.shared.applicationState == .active else {
+            sharedConsentPresenter = presenter
+            observeNextSharedConsentApplicationActivation()
+            return
+        }
+
+        sharedConsentPresenter = nil
+        stopObservingSharedConsentApplicationActivation()
+        ConsentForm.loadAndPresentIfRequired(from: presenter) { formError in
+            DispatchQueue.main.async {
+                #if DEBUG
+                if let formError {
+                    NSLog("Unable to present advertising consent: \(formError.localizedDescription)")
+                }
+                #endif
+                finishSharedConsent(
+                    allowed: formError == nil && ConsentInformation.shared.canRequestAds,
+                    retryableFailure: formError != nil
+                )
+            }
+        }
+    }
+
+    private static func observeNextSharedConsentApplicationActivation() {
+        guard sharedConsentDidBecomeActiveObserver == nil else { return }
+        sharedConsentDidBecomeActiveObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            guard let presenter = sharedConsentPresenter else {
+                finishSharedConsent(allowed: false, retryableFailure: true)
+                return
+            }
+            presentSharedConsentFormWhenActive(from: presenter)
+        }
+    }
+
+    private static func stopObservingSharedConsentApplicationActivation() {
+        guard let observer = sharedConsentDidBecomeActiveObserver else { return }
+        NotificationCenter.default.removeObserver(observer)
+        sharedConsentDidBecomeActiveObserver = nil
+    }
+
     private static func finishSharedConsent(allowed: Bool, retryableFailure: Bool) {
+        stopObservingSharedConsentApplicationActivation()
+        sharedConsentPresenter = nil
         sharedConsentInFlight = false
         sharedConsentComplete = !retryableFailure
         let waiters = sharedConsentWaiters
@@ -580,6 +617,7 @@ public final class MOBAdvertisingBanner: UIViewController, BannerViewDelegate {
     private func replaceBannerView() {
         bannerRetryWorkItem?.cancel()
         bannerRetryWorkItem = nil
+        bannerRetryAttempts = 0
         bannerRequestInFlight = false
         requestedBannerWidth = nil
         adLoaded = false


### PR DESCRIPTION
## Summary
- update the wrapper to Google Mobile Ads 13.6.0 and UMP 3.1.0 on iOS 13+
- gate SDK startup and banner loading behind a fresh, successful consent update and any required UMP form
- bound interrupted ATT, consent, and transient banner retries while cancelling hidden-banner retry work
- use anchored adaptive banners, safe-area layout, and Google demo inventory for Debug/Simulator testing
- replace obsolete setup guidance, including removal of unnecessary arbitrary ATS advice

## Validation
- `python3 -B Tests/test_ad_policy.py`
- `xcrun swiftc -parse _Project/Sources/MOBAdvertisingBanner.swift`
- `pod lib lint MOBAdvertising.podspec --allow-warnings` (passed)
- `git diff --check`